### PR TITLE
ci(finance): pass --impure to nix develop .#ci, fixing the pure-eval failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,10 +200,17 @@ jobs:
         with:
           workspaces: mycelix-finance/tests
       - name: Pack finance DNA
-        run: cd mycelix-finance && nix develop .#ci --command hc dna pack dna/
+        # --impure: the flake's .#ci shell imports ../../nix/modules/
+        # holochain-base.nix, a relative path outside mycelix-finance's own
+        # flake root — flakes evaluate purely by default, so without this
+        # flag `nix develop` fails immediately with "access to absolute
+        # path '/nix/store/nix' is forbidden in pure evaluation mode",
+        # before ever reaching `hc`. Confirmed locally: the same command
+        # fails identically without --impure and proceeds to build with it.
+        run: cd mycelix-finance && nix develop .#ci --impure --command hc dna pack dna/
       - name: Run SweetConductor integration tests
         run: |
-          cd mycelix-finance && nix develop .#ci --command bash -c "
+          cd mycelix-finance && nix develop .#ci --impure --command bash -c "
             cd tests && cargo test -- --include-ignored --test-threads=1
           "
 


### PR DESCRIPTION
## Summary
Follow-up to #11. The new `test-finance-integration` job failed immediately (36s, before ever reaching `hc`):
```
error: access to absolute path '/nix/store/nix' is forbidden in pure evaluation mode (use '--impure' to override)
```
Root cause: `mycelix-finance/flake.nix`'s `.#ci` shell does `import ../../nix/modules/holochain-base.nix` — a relative path reaching outside the flake's own root. Flakes evaluate purely by default, and a path escaping the flake root isn't a tracked/pinned input, so pure-eval rejects it.

## Verification
Confirmed locally: `nix develop .#ci` (no flag) fails with the identical pure-eval message; `nix develop .#ci --impure` gets past that error and proceeds to actually build the nix derivations (it then hit this particular dev box's own unrelated nix-store hardlink-limit issue mid-build, irrelevant to a clean CI runner).

Deliberately did not touch `nix/modules/holochain-base.nix` itself — it's shared across other flakes in this monorepo, and `--impure` on this one job's shell invocation is a smaller, fully-scoped fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
