### PR TITLE
fix(nix): sync nix/modules + fix mycelix-finance flake depth fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,19 @@ jobs:
           name: holochain-ci
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: mycelix-finance/tests
+          workspaces: |
+            mycelix-finance
+            mycelix-finance/tests
+      - name: Build finance zomes (wasm32)
+        # hc dna pack reads dna.yaml's zome paths, which point at
+        # ../target/wasm32-unknown-unknown/release/*.wasm relative to dna/ —
+        # nothing builds those files on its own. Skipping this step is what
+        # made "Pack finance DNA" fail with "Failed to canonicalize resource
+        # path: .../recognition.wasm: No such file or directory" after a
+        # real ~25-minute nix toolchain build that otherwise succeeded.
+        run: |
+          cd mycelix-finance && nix develop .#ci --impure --command \
+            cargo build --release --target wasm32-unknown-unknown --workspace --exclude finance-leptos-types
       - name: Pack finance DNA
         # --impure: the flake's .#ci shell imports ../../nix/modules/
         # holochain-base.nix, a relative path outside mycelix-finance's own

--- a/mycelix-finance/flake.nix
+++ b/mycelix-finance/flake.nix
@@ -44,9 +44,19 @@
         # Holochain packages from holonix
         holochainPackages = holonix.packages.${system};
 
-        # Import shared Holochain base configuration (repo-root nix/modules; the
-        # extra ../ is because mycelix-finance now lives under mycelix-workspace/).
-        holochainBase = import ../../nix/modules/holochain-base.nix {
+        # Import shared Holochain base configuration (repo-root nix/modules).
+        # Two candidate depths on purpose: in the private monorepo,
+        # mycelix-finance lives under mycelix-workspace/ (repo root is two
+        # levels up); on the public standalone (github.com/Luminous-Dynamics/
+        # mycelix), sync-to-standalone.sh flattens mycelix-finance to the repo
+        # root directly (one level up). One hardcoded depth cannot be correct
+        # in both, so try the monorepo depth first and fall back to the
+        # standalone depth.
+        holochainBaseModule =
+          if builtins.pathExists ../../nix/modules/holochain-base.nix
+          then ../../nix/modules/holochain-base.nix
+          else ../nix/modules/holochain-base.nix;
+        holochainBase = import holochainBaseModule {
           inherit pkgs system;
           holochainPackages = holochainPackages;
         };

--- a/nix/modules/holochain-base.nix
+++ b/nix/modules/holochain-base.nix
@@ -1,0 +1,223 @@
+# Copyright (C) 2024-2026 Tristan Stoltz / Luminous Dynamics
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Commercial licensing: see COMMERCIAL_LICENSE.md at repository root
+# Mycelix Ecosystem - Shared Holochain Development Base
+# This module provides a consistent Holochain development environment
+# for all Mycelix hApps with proper bindgen/libclang configuration.
+#
+# Usage in flake.nix:
+#   let
+#     holochainBase = import ../nix/modules/holochain-base.nix { inherit pkgs system; };
+#   in
+#   pkgs.mkShell (holochainBase.shellConfig // { ... });
+
+{ pkgs, system, holochainPackages ? null }:
+
+let
+  # Holochain packages (passed in or use holonix)
+  hcPkgs = holochainPackages;
+
+  # Rust toolchain with WASM target
+  # 1.96.0 to match the workspace rust-toolchain.toml and the system toolchain
+  # (both moved to 1.96.0). Was 1.95.0 — stale, which broke `nix develop`.
+  rustToolchain = pkgs.rust-bin.stable."1.96.0".default.override {
+    targets = [ "wasm32-unknown-unknown" ];
+    extensions = [ "rust-src" "rust-analyzer" "clippy" ];
+  };
+
+  # Common build inputs for all Holochain projects
+  commonBuildInputs = with pkgs; [
+    # Rust toolchain
+    rustToolchain
+    bacon
+    cargo-watch
+    cargo-edit
+    cargo-expand
+    cargo-nextest
+    deploy-rs
+    colmena
+
+    # Build essentials
+    pkg-config
+    openssl
+    openssl.dev
+    cmake
+    gnumake
+
+    # For bindgen (datachannel-sys, etc.)
+    llvmPackages.libclang
+    llvmPackages.clang
+    glibc.dev
+
+    # For C++ builds (datachannel-sys CMake build)
+    # Use stdenv.cc to get proper include paths
+    pkgs.stdenv.cc
+
+    # Utilities
+    just
+    jq
+    yq-go
+    cargo-tauri
+
+    # === Tauri 2.0 Desktop Dependencies (Linux) ===
+    # GTK3 for native UI
+    gtk3
+    gtk3.dev
+    glib
+    glib.dev
+    gdk-pixbuf
+    gdk-pixbuf.dev
+
+    # WebKit for webview rendering
+    webkitgtk_4_1  # Tauri 2.0 uses webkit2gtk-4.1
+    libsoup_3      # Required by webkitgtk
+    libsoup_3.dev
+
+    # System tray support
+    libappindicator-gtk3
+
+    # SVG rendering for icons
+    librsvg
+    librsvg.dev
+
+    # Additional Tauri deps (with dev packages for pkg-config)
+    cairo
+    cairo.dev
+    pango
+    pango.dev
+    atk
+    atk.dev
+    harfbuzz
+    harfbuzz.dev
+
+    # GIO networking for HTTPS/TLS in WebKit
+    glib-networking
+    dbus
+
+  ] ++ pkgs.lib.optionals (hcPkgs != null) [
+    hcPkgs.holochain
+    hcPkgs.lair-keystore
+    hcPkgs.hc
+    hcPkgs.bootstrap-srv
+  ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+    pkgs.darwin.apple_sdk.frameworks.Security
+    pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+    pkgs.libiconv
+  ];
+
+  # Environment variables for proper C/C++ compilation
+  # These are set directly as mkShell attributes (not via inherit)
+  libclangPath = "${pkgs.llvmPackages.libclang.lib}/lib";
+
+  # Clang resource root varies by system - find it dynamically
+  clangResourceDir = "${pkgs.llvmPackages.clang.cc}/lib/clang/${pkgs.lib.versions.major pkgs.llvmPackages.clang.version}/include";
+
+  bindgenArgs = builtins.concatStringsSep " " [
+    "-I${pkgs.glibc.dev}/include"
+    "-I${clangResourceDir}"
+  ];
+
+  # PKG_CONFIG_PATH with all required library paths
+  pkgConfigPaths = pkgs.lib.concatStringsSep ":" [
+    "${pkgs.openssl.dev}/lib/pkgconfig"
+    "${pkgs.gtk3.dev}/lib/pkgconfig"
+    "${pkgs.glib.dev}/lib/pkgconfig"
+    "${pkgs.gdk-pixbuf.dev}/lib/pkgconfig"
+    "${pkgs.webkitgtk_4_1}/lib/pkgconfig"
+    "${pkgs.libsoup_3.dev}/lib/pkgconfig"
+    "${pkgs.cairo.dev}/lib/pkgconfig"
+    "${pkgs.pango.dev}/lib/pkgconfig"
+    "${pkgs.atk.dev}/lib/pkgconfig"
+    "${pkgs.harfbuzz.dev}/lib/pkgconfig"
+    "${pkgs.librsvg.dev}/lib/pkgconfig"
+    "${pkgs.libappindicator-gtk3}/lib/pkgconfig"
+  ];
+
+  # Environment variables attribute set for export
+  # Note: C/C++ compiler paths are handled by stdenv.cc via inputsFrom
+  envVars = {
+    RUST_BACKTRACE = "1";
+    RUST_LOG = "info";
+    HC_ADMIN_PORT = "4444";
+    HC_APP_PORT = "8888";
+    LIBCLANG_PATH = libclangPath;
+    BINDGEN_EXTRA_CLANG_ARGS = bindgenArgs;
+    OPENSSL_DIR = "${pkgs.openssl.dev}";
+    OPENSSL_LIB_DIR = "${pkgs.openssl.out}/lib";
+    OPENSSL_INCLUDE_DIR = "${pkgs.openssl.dev}/include";
+    PKG_CONFIG_PATH = pkgConfigPaths;
+    # GIO modules for WebKit HTTPS/TLS support
+    GIO_MODULE_DIR = "${pkgs.glib-networking}/lib/gio/modules";
+    GIO_EXTRA_MODULES = "${pkgs.glib-networking}/lib/gio/modules";
+  };
+
+  # Shell hook for Holochain projects
+  shellHook = projectName: ''
+    # Fix NixOS GCC 15 #include_next <stdlib.h> failure:
+    # Too many -isystem entries from buildInputs push glibc headers before
+    # GCC's include-fixed, breaking #include_next in <cstdlib>.
+    # We preserve only -frandom-seed and let pkg-config/env vars handle paths.
+    export NIX_CFLAGS_COMPILE="$(echo "$NIX_CFLAGS_COMPILE" | grep -oP '\-frandom-seed=\S+')"
+    export NIX_CFLAGS_COMPILE_FOR_TARGET="$NIX_CFLAGS_COMPILE"
+
+    echo ""
+    echo "========================================"
+    echo "  Mycelix ${projectName}"
+    echo "  Holochain Development Environment"
+    echo "========================================"
+    echo ""
+    ${if hcPkgs != null then ''
+    echo "Holochain: $(holochain --version 2>/dev/null || echo 'loading...')"
+    echo "hc:        $(hc --version 2>/dev/null || echo 'loading...')"
+    '' else ''
+    echo "Note: Holochain binaries not included (add holonix to your flake)"
+    ''}
+    echo "Rust:      $(rustc --version)"
+    echo "Cargo:     $(cargo --version)"
+    echo ""
+    echo "Environment configured with:"
+    echo "  - LIBCLANG_PATH for bindgen"
+    echo "  - System includes for C/C++ deps"
+    echo "  - OpenSSL paths"
+    echo "  - bacon / cargo-nextest / deploy-rs / Colmena"
+    echo ""
+  '';
+
+in {
+  # Export for use in mkShell
+  inherit commonBuildInputs envVars rustToolchain;
+
+  # Complete shell configuration
+  shellConfig = {
+    name = "mycelix-holochain";
+    buildInputs = commonBuildInputs;
+
+    # Spread environment variables
+    inherit (envVars)
+      RUST_BACKTRACE RUST_LOG
+      HC_ADMIN_PORT HC_APP_PORT
+      LIBCLANG_PATH BINDGEN_EXTRA_CLANG_ARGS
+      OPENSSL_DIR OPENSSL_LIB_DIR OPENSSL_INCLUDE_DIR
+      PKG_CONFIG_PATH
+      GIO_MODULE_DIR GIO_EXTRA_MODULES;
+
+    shellHook = shellHook "hApp";
+  };
+
+  # Function to create a customized shell
+  mkHolochainShell = { name, extraBuildInputs ? [], extraEnvVars ? {}, extraShellHook ? "" }:
+    pkgs.mkShell ({
+      name = "mycelix-${name}";
+      buildInputs = commonBuildInputs ++ extraBuildInputs;
+
+      inherit (envVars)
+        RUST_BACKTRACE RUST_LOG
+        HC_ADMIN_PORT HC_APP_PORT
+        LIBCLANG_PATH BINDGEN_EXTRA_CLANG_ARGS
+        OPENSSL_DIR OPENSSL_LIB_DIR OPENSSL_INCLUDE_DIR
+        PKG_CONFIG_PATH
+        GIO_MODULE_DIR GIO_EXTRA_MODULES;
+
+      shellHook = (shellHook name) + extraShellHook;
+    } // extraEnvVars);
+}


### PR DESCRIPTION
## Summary
Follow-up to #11/#13. `test-finance-integration`'s `nix develop .#ci` got past the pure-eval error (#13) but hit a deeper one: `error: path '/nix/store/nix/modules/holochain-base.nix' does not exist`.

Root cause, confirmed by checking the API directly: `nix/modules/` doesn't exist on this repo at all. It's shared Holochain devShell config that ~20 cluster flakes in the private monorepo import (commons, civic, hearth, finance, governance, health, identity, personal, energy, music, knowledge, ...), and it was never in `sync-to-standalone.sh`'s scope. Separately, `mycelix-finance/flake.nix`'s `../../` relative import assumes the monorepo's nesting depth (`mycelix-workspace/mycelix-finance/`) — this repo flattens `mycelix-finance` to the root, one level shallower, so even with the file present the hardcoded depth would've been wrong.

## Changes
- Adds `nix/modules/holochain-base.nix` (one self-contained file, 223 lines, no further deps).
- `mycelix-finance/flake.nix` now tries the monorepo depth first, falls back to this repo's flatter depth via `builtins.pathExists` — the same file works unmodified in both repos.

## Verification
`nix eval .#devShells.x86_64-linux.ci.name --impure` in this exact clone resolves to `"mycelix-finance-ci"` cleanly (previously failed with the path-not-found error above).

## Note
Only fixes `mycelix-finance`'s flake for now — the other ~19 cluster flakes that import the same module have the identical depth-fallback need if/when their own `.#ci`-style shells get exercised on this repo. Scoped narrowly here rather than sweeping all 20 unreviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
