### PR TITLE
research(im): publish IM-001 preregistration and dataset-freeze evidence

### DIFF
--- a/research/im001-public-v19/DATASET_ACQUISITION.md
+++ b/research/im001-public-v19/DATASET_ACQUISITION.md
@@ -1,0 +1,23 @@
+# IM-001 — Official Dataset Acquisition / Freeze Contract
+
+The primary corpus remains **CSE-CIC-IDS2018**, using the University of New Brunswick Canadian Institute for Cybersecurity's official dataset page and public AWS bucket.
+
+The official source documents seven attack scenarios and an AWS acquisition route using `s3://cse-cic-ids2018/`; the experiment must record source/citation terms, exact acquired objects, byte sizes and SHA-256 hashes before transformation.
+
+## Freeze contract
+
+The dataset-manifest freezer converts an acquired directory into a deterministic relative-path / byte-size / SHA-256 manifest and intentionally refuses empty/nonexistent directories.
+
+The following remain blocked until the real corpus is acquired:
+
+- dataset object/file hashes;
+- exact object listing;
+- derived-table hashes;
+- client partitions;
+- transformation revision;
+- final held-out attack lineage;
+- final metric thresholds.
+
+## Epistemic boundary
+
+No dataset file hashes are claimed by this branch. Selecting the official route reduces ambiguity around *what to acquire* while preserving the real preregistration gate around *which exact files, transformations and lineages are used*.

--- a/research/im001-public-v19/PREREGISTRATION_SEED.md
+++ b/research/im001-public-v19/PREREGISTRATION_SEED.md
@@ -1,0 +1,90 @@
+# IM-001A — Public Preregistration Seed
+
+**Status:** experiment-contract draft; no performance result is claimed.
+**Question:** can a collaborative defensive-learning protocol improve detection of held-out attack families without centralizing raw client telemetry, while remaining acceptably robust to malicious participants, privacy attacks and false-positive/"autoimmune" regressions?
+
+## Primary corpus
+
+**CSE-CIC-IDS2018** from the Canadian Institute for Cybersecurity / University of New Brunswick.
+
+Record at acquisition time:
+
+- official source URL and citation;
+- source/redistribution terms;
+- downloaded-file hashes;
+- transformation-code revision;
+- split/index hashes.
+
+Use CIC-IDS2017 only as an external dataset-shift check after the primary protocol is frozen. CICDDoS2019 is optional for a deliberately scoped DDoS analysis, not automatic scope expansion.
+
+## Phase 0 — calibration only
+
+Use a designated calibration subset to decide:
+
+- feature normalization / compatible feature set;
+- number and construction of simulated organizations/clients;
+- class-balance treatment;
+- named malicious-client regimes;
+- numeric decision thresholds for transfer, privacy, false-positive and Byzantine outcomes.
+
+The final attack-family holdout and external-shift evaluation are not inspected here.
+
+## Non-IID organization simulation
+
+Construct client partitions by host/subnet/day or another published deterministic grouping that produces heterogeneous local views. Do not use IID random sharding as the only setting.
+
+## Required comparison arms
+
+1. local-only learning;
+2. centralized pooled-data research reference/upper baseline;
+3. ordinary collaborative/federated baseline;
+4. IM-001 candidate protocol.
+
+This prevents “federated beats nothing” from being counted as evidence.
+
+## Held-out transfer
+
+Freeze at least one complete attack family/sub-family from collaborative training by a deterministic preregistered rule. Do not choose the holdout after seeing which family gives the best result.
+
+## Hostile-participant and privacy regimes
+
+Freeze named regimes before final holdout, including a subset of:
+
+- benign clients;
+- malicious-client fractions selected during calibration;
+- random / sign-flip Byzantine updates;
+- targeted poisoning/backdoor behavior;
+- membership-inference or update-leakage attack against the collaboration mechanism.
+
+## Primary outcomes
+
+- held-out-family detection relative to local-only and ordinary federated baselines;
+- false-positive / autoimmune regression;
+- privacy attack success / leakage metric;
+- degradation under named malicious-client regimes;
+- clean-task performance cost;
+- stability under external dataset shift.
+
+## Freeze point
+
+Before final holdout evaluation, publish or hash-pin:
+
+- train/calibration/holdout indexes;
+- model/protocol configuration;
+- hostile regimes;
+- primary metrics and thresholds;
+- random-seed policy;
+- analysis revision.
+
+## Interpretation
+
+A successful project does not require a positive result.
+
+- No transfer benefit → reject/weaken the cyber-immunity claim.
+- Transfer with unacceptable false positives → report autoimmune failure.
+- Privacy leakage or poisoning fragility → report the mechanism unsafe under that regime.
+- Benefit that disappears under external dataset shift → constrain the claim to the source environment.
+
+## Non-claims
+
+Public CIC benchmark traffic is not live enterprise/customer telemetry. The experiment tests reproducible research conditions and does not establish production efficacy, deployment safety or universal cyber-immunity.

--- a/research/im001-public-v19/PUBLIC_RESULTS.json
+++ b/research/im001-public-v19/PUBLIC_RESULTS.json
@@ -1,0 +1,28 @@
+{
+  "artifact": "IM-001 public results summary v19",
+  "claim_boundary": "Preregistration/pipeline tooling and synthetic sensitivity only; no real IDS/cyber-immunity result.",
+  "dataset_manifest_tool": {
+    "empty_directory_refused": true,
+    "synthetic_file_count": 2,
+    "two_run_stable_hash_equal": true
+  },
+  "prereg": {
+    "blocker_count": 25,
+    "final_holdout_permitted": false,
+    "status": "PRECALIBRATION_CONTRACT_PASS_FINAL_HOLDOUT_BLOCKED"
+  },
+  "synthetic_pipeline_summary": {
+    "0.00": {
+      "coordinate_median": {"max_fpr": 0.075, "mean_fpr": 0.049466666666666666, "mean_heldout_tpr": 0.6642, "min_heldout_tpr": 0.567},
+      "mean": {"max_fpr": 0.106, "mean_fpr": 0.0508, "mean_heldout_tpr": 0.6650666666666667, "min_heldout_tpr": 0.582}
+    },
+    "0.20": {
+      "coordinate_median": {"max_fpr": 0.082, "mean_fpr": 0.053899999999999997, "mean_heldout_tpr": 0.6092666666666666, "min_heldout_tpr": 0.481},
+      "mean": {"max_fpr": 0.071, "mean_fpr": 0.0483, "mean_heldout_tpr": 0.31489999999999996, "min_heldout_tpr": 0.163}
+    },
+    "0.35": {
+      "coordinate_median": {"max_fpr": 0.073, "mean_fpr": 0.05493333333333333, "mean_heldout_tpr": 0.45803333333333335, "min_heldout_tpr": 0.22},
+      "mean": {"max_fpr": 0.078, "mean_fpr": 0.05143333333333333, "mean_heldout_tpr": 0.0008666666666666667, "min_heldout_tpr": 0.0}
+    }
+  }
+}

--- a/research/im001-public-v19/README.md
+++ b/research/im001-public-v19/README.md
@@ -1,0 +1,20 @@
+# IM-001 public evidence — v19
+
+This review branch publishes the v19 IM-001 preregistration/pipeline evidence against reviewed `mycelix` main `7daefcbfa6c4427809e9d8dc24a039bb024da5e9`.
+
+## Current evidence
+
+- Machine-readable preregistration structure passes but final holdout remains blocked.
+- The current checker reports 25 unresolved scientific/data freeze blockers.
+- Dataset-manifest freezer is deterministic on a fixed synthetic smoke and refuses an empty dataset directory.
+- Synthetic lineage-disjoint federated pipeline smoke exercises malicious clients, ordinary mean vs coordinate-median aggregation, held-out detection, and false-positive accounting.
+
+## Interpretation
+
+This is **pipeline and preregistration-tooling evidence only**. The official CSE-CIC-IDS2018 dataset has not been acquired/hash-frozen in this tranche, and no real-world cyber-immunity, IDS performance, privacy, or Byzantine-robustness claim is made.
+
+The exact addition-only v19 patch is preserved in the funding/publication handoff and expands to the complete `research/im001/` tranche.
+
+## Non-claims
+
+This branch does not claim operational IDS performance, privacy preservation, Byzantine robustness, successful defensive transfer, or a completed preregistration.


### PR DESCRIPTION
## Purpose

Publish a bounded reviewer surface for IM-001 preregistration and synthetic-pipeline evidence.

This PR is **draft/review-only**. It does not claim real-world IDS performance or cyber-immunity.

## Evidence currently reported

- Machine-readable preregistration structure passes, but final holdout remains blocked.
- 25 scientific/data freeze blockers remain unresolved.
- Dataset-manifest freezer is deterministic on fixed synthetic files and refuses an empty dataset directory.
- Synthetic lineage-disjoint federated pipeline smoke exercises malicious clients, ordinary mean vs coordinate-median aggregation, held-out detection, and false-positive accounting.

## Included reviewer artifacts

- `PREREGISTRATION_SEED.md` — pre-results experimental contract and amendment policy.
- `DATASET_ACQUISITION.md` — official CSE-CIC-IDS2018 acquisition/hash-freeze boundary.
- `PUBLIC_RESULTS.json` — machine-readable current evidence state.
- `README.md` — concise interpretation and non-claims.

## What this does not prove

No claim of operational IDS performance, successful defensive transfer, privacy preservation, Byzantine robustness, or completed preregistration is made. The real corpus has not yet been acquired/hash-frozen in this tranche.

## Review question

The most useful critique is: **what data split, leakage path, poisoning setup, or false-positive failure mode could make the eventual held-out transfer result misleading?**

The full executable v19/v20 handoff remains separately reproducible and pinned to the reviewed base SHA.